### PR TITLE
Add role-based authentication and user dashboards

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,14 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
 from pathlib import Path
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -78,6 +81,51 @@ activities = {
 }
 
 
+# Simple in-memory users and sessions for role-based access.
+users = {
+    "student1": {"password": "student123", "role": "student"},
+    "staff1": {"password": "staff123", "role": "staff"},
+    "admin1": {"password": "admin123", "role": "admin"},
+}
+sessions = {}
+security = HTTPBearer(auto_error=False)
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class CreateActivityRequest(BaseModel):
+    name: str
+    description: str
+    schedule: str
+    max_participants: int
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+):
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    token = credentials.credentials
+    user = sessions.get(token)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    return user
+
+
+def require_roles(*allowed_roles: str):
+    def role_dependency(current_user=Depends(get_current_user)):
+        if current_user["role"] not in allowed_roles:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return current_user
+
+    return role_dependency
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,8 +136,45 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def login(payload: LoginRequest):
+    user_record = users.get(payload.username)
+    if user_record is None or user_record["password"] != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(24)
+    sessions[token] = {
+        "username": payload.username,
+        "role": user_record["role"],
+    }
+
+    return {
+        "token": token,
+        "username": payload.username,
+        "role": user_record["role"],
+    }
+
+
+@app.get("/auth/me")
+def me(current_user=Depends(get_current_user)):
+    return current_user
+
+
+@app.post("/auth/logout")
+def logout(credentials: HTTPAuthorizationCredentials | None = Depends(security)):
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    sessions.pop(credentials.credentials, None)
+    return {"message": "Logged out successfully"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    _current_user=Depends(require_roles("staff", "admin")),
+):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +196,11 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    _current_user=Depends(require_roles("staff", "admin")),
+):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -130,3 +219,24 @@ def unregister_from_activity(activity_name: str, email: str):
     # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}
+
+
+@app.post("/admin/activities")
+def create_activity(
+    payload: CreateActivityRequest,
+    _current_user=Depends(require_roles("admin")),
+):
+    if payload.name in activities:
+        raise HTTPException(status_code=400, detail="Activity already exists")
+
+    if payload.max_participants < 1:
+        raise HTTPException(status_code=400, detail="max_participants must be at least 1")
+
+    activities[payload.name] = {
+        "description": payload.description,
+        "schedule": payload.schedule,
+        "max_participants": payload.max_participants,
+        "participants": [],
+    }
+
+    return {"message": f"Created activity {payload.name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -2,7 +2,85 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
+  const loginForm = document.getElementById("login-form");
+  const createActivityForm = document.getElementById("create-activity-form");
+  const logoutBtn = document.getElementById("logout-btn");
+  const sessionLabel = document.getElementById("session-label");
+  const loginPanel = document.getElementById("login-panel");
+  const studentDashboard = document.getElementById("student-dashboard");
+  const staffDashboard = document.getElementById("staff-dashboard");
+  const adminDashboard = document.getElementById("admin-dashboard");
   const messageDiv = document.getElementById("message");
+
+  let authToken = localStorage.getItem("authToken") || "";
+  let currentUser = null;
+
+  function showMessage(type, text) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function getAuthHeaders() {
+    if (!authToken) {
+      return {};
+    }
+
+    return {
+      Authorization: `Bearer ${authToken}`,
+    };
+  }
+
+  function updateDashboardVisibility() {
+    const role = currentUser?.role;
+    const isStaff = role === "staff";
+    const isAdmin = role === "admin";
+    const isStudent = role === "student";
+
+    loginPanel.classList.toggle("hidden", Boolean(currentUser));
+    logoutBtn.classList.toggle("hidden", !currentUser);
+    studentDashboard.classList.toggle("hidden", !isStudent);
+    staffDashboard.classList.toggle("hidden", !(isStaff || isAdmin));
+    adminDashboard.classList.toggle("hidden", !isAdmin);
+
+    if (currentUser) {
+      sessionLabel.textContent = `Signed in as ${currentUser.username} (${currentUser.role})`;
+    } else {
+      sessionLabel.textContent = "Not signed in";
+    }
+  }
+
+  async function refreshSession() {
+    if (!authToken) {
+      currentUser = null;
+      updateDashboardVisibility();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: {
+          ...getAuthHeaders(),
+        },
+      });
+
+      if (!response.ok) {
+        authToken = "";
+        currentUser = null;
+        localStorage.removeItem("authToken");
+      } else {
+        currentUser = await response.json();
+      }
+    } catch (error) {
+      currentUser = null;
+    }
+
+    updateDashboardVisibility();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +90,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
+
+      const canManageParticipants =
+        currentUser?.role === "staff" || currentUser?.role === "admin";
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -28,10 +110,12 @@ document.addEventListener("DOMContentLoaded", () => {
               <h5>Participants:</h5>
               <ul class="participants-list">
                 ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
+                  .map((email) => {
+                    const removeButton = canManageParticipants
+                      ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                      : "";
+                    return `<li><span class="participant-email">${email}</span>${removeButton}</li>`;
+                  })
                   .join("")}
               </ul>
             </div>`
@@ -57,9 +141,11 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (canManageParticipants) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -80,37 +166,87 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            ...getAuthHeaders(),
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage("success", result.message);
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage("error", result.detail || "An error occurred");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("error", "Failed to unregister. Please try again.");
       console.error("Error unregistering:", error);
     }
   }
 
-  // Handle form submission
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage("error", result.detail || "Login failed");
+        return;
+      }
+
+      authToken = result.token;
+      localStorage.setItem("authToken", authToken);
+      currentUser = {
+        username: result.username,
+        role: result.role,
+      };
+      updateDashboardVisibility();
+      loginForm.reset();
+      showMessage("success", `Welcome ${currentUser.username}`);
+      fetchActivities();
+    } catch (error) {
+      showMessage("error", "Login failed. Please try again.");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: {
+          ...getAuthHeaders(),
+        },
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    authToken = "";
+    currentUser = null;
+    localStorage.removeItem("authToken");
+    updateDashboardVisibility();
+    showMessage("info", "Logged out");
+    fetchActivities();
+  });
+
+  // Handle staff/admin registration form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
@@ -124,37 +260,64 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            ...getAuthHeaders(),
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage("success", result.message);
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage("error", result.detail || "An error occurred");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("error", "Failed to sign up. Please try again.");
       console.error("Error signing up:", error);
     }
   });
 
+  createActivityForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const payload = {
+      name: document.getElementById("new-activity-name").value,
+      description: document.getElementById("new-activity-description").value,
+      schedule: document.getElementById("new-activity-schedule").value,
+      max_participants: Number(document.getElementById("new-activity-max").value),
+    };
+
+    try {
+      const response = await fetch("/admin/activities", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...getAuthHeaders(),
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage("success", result.message);
+        createActivityForm.reset();
+        fetchActivities();
+      } else {
+        showMessage("error", result.detail || "Failed to create activity");
+      }
+    } catch (error) {
+      showMessage("error", "Failed to create activity. Please try again.");
+      console.error("Error creating activity:", error);
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  refreshSession().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,33 +10,89 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-status" class="auth-status">
+        <span id="session-label">Not signed in</span>
+        <button id="logout-btn" class="hidden" type="button">Logout</button>
+      </div>
     </header>
 
     <main>
       <section id="activities-container">
         <h3>Available Activities</h3>
         <div id="activities-list">
-          <!-- Activities will be loaded here -->
           <p>Loading activities...</p>
         </div>
       </section>
 
-      <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
-        <form id="signup-form">
-          <div class="form-group">
-            <label for="email">Student Email:</label>
-            <input type="email" id="email" required placeholder="your-email@mergington.edu" />
-          </div>
-          <div class="form-group">
-            <label for="activity">Select Activity:</label>
-            <select id="activity" required>
-              <option value="">-- Select an activity --</option>
-              <!-- Activity options will be loaded here -->
-            </select>
-          </div>
-          <button type="submit">Sign Up</button>
-        </form>
+      <section id="dashboard-container">
+        <h3>User Access</h3>
+
+        <div id="login-panel">
+          <h4>Login</h4>
+          <form id="login-form">
+            <div class="form-group">
+              <label for="username">Username:</label>
+              <input type="text" id="username" required placeholder="student1 / staff1 / admin1" />
+            </div>
+            <div class="form-group">
+              <label for="password">Password:</label>
+              <input type="password" id="password" required placeholder="Enter password" />
+            </div>
+            <button type="submit">Login</button>
+          </form>
+          <p class="hint">Demo accounts: student1/student123, staff1/staff123, admin1/admin123</p>
+        </div>
+
+        <div id="student-dashboard" class="hidden role-panel">
+          <h4>Student Dashboard</h4>
+          <p>You can browse activities and current participants. Registration changes are managed by staff.</p>
+        </div>
+
+        <div id="staff-dashboard" class="hidden role-panel">
+          <h4>Staff Dashboard</h4>
+          <form id="signup-form">
+            <div class="form-group">
+              <label for="email">Student Email:</label>
+              <input type="email" id="email" required placeholder="your-email@mergington.edu" />
+            </div>
+            <div class="form-group">
+              <label for="activity">Select Activity:</label>
+              <select id="activity" required>
+                <option value="">-- Select an activity --</option>
+              </select>
+            </div>
+            <button type="submit">Register Student</button>
+          </form>
+        </div>
+
+        <div id="admin-dashboard" class="hidden role-panel">
+          <h4>Admin Dashboard</h4>
+          <form id="create-activity-form">
+            <div class="form-group">
+              <label for="new-activity-name">Activity Name:</label>
+              <input type="text" id="new-activity-name" required placeholder="GitHub Skills" />
+            </div>
+            <div class="form-group">
+              <label for="new-activity-description">Description:</label>
+              <input
+                type="text"
+                id="new-activity-description"
+                required
+                placeholder="Learn practical coding and collaboration"
+              />
+            </div>
+            <div class="form-group">
+              <label for="new-activity-schedule">Schedule:</label>
+              <input type="text" id="new-activity-schedule" required placeholder="Fridays, 3:30 PM - 5:00 PM" />
+            </div>
+            <div class="form-group">
+              <label for="new-activity-max">Max Participants:</label>
+              <input type="number" id="new-activity-max" min="1" required />
+            </div>
+            <button type="submit">Create Activity</button>
+          </form>
+        </div>
+
         <div id="message" class="hidden"></div>
       </section>
     </main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -24,6 +24,19 @@ header {
   border-radius: 5px;
 }
 
+.auth-status {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.auth-status button {
+  padding: 6px 12px;
+  font-size: 14px;
+}
+
 header h1 {
   margin-bottom: 10px;
 }
@@ -132,6 +145,18 @@ section h3 {
 
 .form-group {
   margin-bottom: 15px;
+}
+
+.role-panel {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #eee;
+}
+
+.hint {
+  margin-top: 10px;
+  color: #666;
+  font-size: 14px;
 }
 
 .form-group label {


### PR DESCRIPTION
## Summary
- add token-based login/logout/session endpoints with role information
- enforce role-based permissions for activity registration and unregistration
- add admin-only activity creation endpoint
- update frontend with login/logout UI and role-specific dashboard panels (student, staff, admin)
- wire client authorization headers and session restore logic

## Demo Accounts
- student1 / student123
- staff1 / staff123
- admin1 / admin123

## Why
Implements issue #8 by introducing role-aware access and dashboard behavior as the foundation for secure staff/admin workflows.

Closes #8